### PR TITLE
Added a couple of tests and proved any date format works.

### DIFF
--- a/src/baklabel/test_baklabel.py
+++ b/src/baklabel/test_baklabel.py
@@ -413,6 +413,14 @@ class TestBaklabel(unittest.TestCase):
         result = tsto.label()
         self.assertEqual(result, expected)
 
+    def test_al_bday_mon(self):
+        """ 25 """
+        dday = date(1960, 5, 23)
+        expected = 'mon'
+        tsto = Grandad(dday)
+        result = tsto.label()
+        self.assertEqual(result, expected)
+
     def test_force_no_weekly_day_next_thu(self):
         """ 24 """
         dday = date(2040, 3, 8)
@@ -678,6 +686,11 @@ class TestGuessdate(unittest.TestCase):
         dlst = 5, 6, 2023
         dstr = "-".join(str(item) for item in dlst)
         self.assertEqual(str(guessdate(dstr)), '2023-06-05')
+
+    def test_al_bday(self):
+        dlst = 23, 5, 1960
+        dstr = "-".join(str(item) for item in dlst)
+        self.assertEqual(str(guessdate(dstr)), '1960-05-23')
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
The github codespace version of baklabel (mentioned by @awaddell) didn't handle a 'foreign' date format whereas the foreign-format date tests all pass. 
Built into baklabel is 'guessdate' which (for ambiguous date formatting like 5/6/2023) will look for the proper date format of the operating system. If the running version of baklabel is in a Docker container there might be conflicting date formats depending on where the container was built versus where it is running.
At this point I haven't built any Docker containers for testing.